### PR TITLE
Configure Travis to build website on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ sudo: false
 notifications:
   email: false
 
-# Only build pushes from the master branch. PRs are always built.
-branches:
-  only:
-    - website
-
 env:
   global:
     # Github Token (GH_TOKEN)


### PR DESCRIPTION
Letting travis to build the website on every branch will allow to check if has any errors before creating a PR.