### PR TITLE
Fix name of the repo containing the website source code

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -32,7 +32,7 @@ reflinks:
         title: Bootswatch
         url: http://bootswatch.com
     website_repo:
-        title: mecanica-estadistica/website
+        title: santisoler/mecanica-estadistica
         url: https://www.github.com/santisoler/mecanica-estadistica/tree/website
     license:
         title: CC-BY-SA


### PR DESCRIPTION
Change the repo link `mecanica-estadistica/website` to `santisoler/mecanica-estadistica` on footer.