### PR TITLE
Allow Travis builds only on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ language: bash
 notifications:
     email: false
 
+# Only build pushes from the master branch. PRs are always built.
+branches:
+  only:
+    - master
+
 # Install dependencies (latex)
 before_install:
     - sudo apt-get -q update


### PR DESCRIPTION
Following the same logic that #14, we don't want to have builds on branches other than `master`.
It's better to create a PR and then build from there.